### PR TITLE
Bugfix: Remove collision_radius param, not a part of a FlightMode msg

### DIFF
--- a/nodes/python_ros_node_template.py
+++ b/nodes/python_ros_node_template.py
@@ -243,7 +243,6 @@ class SimpleControlExample(object):
 
         fm.name = "difficult"
 
-        fm.collision_radius = 0.25
         fm.control_enabled = False
 
         fm.att_ki = Vec(0.002, 0.002, 0.002)


### PR DESCRIPTION
I was experimenting with your repo and ran into some issues, apparently collision_radius is no longer a part of a FlightMode message, which led to this error prior to this fix. I could be misinterpreting what's going on with the FlightMode message though, feel free to let me know if that is the case. Thought this might be helpful
```
Traceback (most recent call last):
  File "/home/dan/experimenting/catkin_ws/src/astrobee_ros_demo/nodes/python_ros_node_template.py", line 315, in <module>
    dmpc = SimpleControlExample()
  File "/home/dan/experimenting/catkin_ws/src/astrobee_ros_demo/nodes/python_ros_node_template.py", line 53, in __init__
    self.run()
  File "/home/dan/experimenting/catkin_ws/src/astrobee_ros_demo/nodes/python_ros_node_template.py", line 304, in run
    fm = self.create_flight_mode_message()
  File "/home/dan/experimenting/catkin_ws/src/astrobee_ros_demo/nodes/python_ros_node_template.py", line 246, in create_flight_mode_message
    fm.collision_radius = 0.25
AttributeError: 'FlightMode' object has no attribute 'collision_radius'
```